### PR TITLE
accidentally get other room's post by name-specified substitution

### DIFF
--- a/src/substitute_lingrbot/core.clj
+++ b/src/substitute_lingrbot/core.clj
@@ -38,10 +38,11 @@
                (re-find #"^s/((?:\\.|[^/])+)/((?:\\.|[^/])*)/g?\s*(<\s*@?(.*))?$" text)]
         (if target-nick
           (let [new-text
-                (s/replace (get @previous-text target-nick "")
+                (s/replace (get (get @previous-text target-nick {}) room "")
                                         (re-pattern (s/replace left #"\\(.)" "$1"))
                                         (s/replace right #"\\(.)" "$1"))]
-            (swap! previous-text assoc target-nick new-text)
+            (swap! previous-text assoc target-nick
+                   (assoc (get @previous-text target-nick {}) room new-text))
             (format "%s" new-text))
           (let [latest-text (last (get @latest-texts room [""])) ; TODO
                 new-text
@@ -52,7 +53,8 @@
               (swap! latest-texts assoc room (conj texts new-text)))
             (format "%s" new-text)))
         (do
-          (swap! previous-text assoc nick text)
+          (swap! previous-text assoc nick
+                 (assoc (get @previous-text nick {}) room text))
           (let [texts (get @latest-texts room [""])]
             (swap! latest-texts assoc room (conj texts text)))
           "")))))


### PR DESCRIPTION
Review plz.

個人的には `(get @previous-text target-nick {})` `(get @previous-text nick {})` が出まくるのが汚く見えるんですが、変数として置くならどこでやるべきかというのとそもそももっといい方法が無いかというのが気になります。ｸﾛｰｼﾞｬｱｧｰ分からないマンなのでよろしくお願いします。
